### PR TITLE
Remove volume_ml from beer related code

### DIFF
--- a/src/api/beers.ts
+++ b/src/api/beers.ts
@@ -15,10 +15,6 @@ export type BeersParams = {
   percentage__lte?: number;
   percentage__range?: string;
   percentage?: number;
-  volume_ml__gte?: number;
-  volume_ml__lte?: number;
-  volume_ml__range?: string;
-  volume_ml?: number;
   hop_rate__gte?: number;
   hop_rate__lte?: number;
   hop_rate__range?: string;
@@ -42,7 +38,6 @@ export interface BeerCreatePayload {
   brewery: number;
   style: number;
   percentage: number;
-  volume_ml: number;
   hop_rate: number | null;
   extract: number | null;
   IBU: number | null;

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -58,7 +58,6 @@ export interface Beer {
   style: BeerStyle;
   hops: Hop[];
   percentage: number;
-  volume_ml: number;
   extract: Nullable<number>;
   IBU: Nullable<number>;
   hop_rate: Nullable<number>;
@@ -73,7 +72,6 @@ export interface BeerDetail {
   style: BeerStyleEmbedded;
   hops: HopEmbedded[];
   percentage: number;
-  volume_ml: number;
   extract: Nullable<number>;
   IBU: Nullable<number>;
   hop_rate: Nullable<number>;
@@ -224,7 +222,6 @@ export interface BeerObject {
   id: number;
   name: string;
   percentage: number;
-  volume_ml: number;
   extract: number;
   IBU: number;
   hop_rate: number;
@@ -244,7 +241,6 @@ export interface BeerEmbedded {
   hops: number[];
   image: Nullable<string>;
   percentage: number;
-  volume_ml: number;
   hop_rate: Nullable<number>;
   extract: Nullable<number>;
   IBU: Nullable<number>;

--- a/src/components/dashboard/browser/BeerAddModal.tsx
+++ b/src/components/dashboard/browser/BeerAddModal.tsx
@@ -40,7 +40,6 @@ type BeerAddForm = {
   brewery: string | null;
   style: string | null;
   percentage: "" | number;
-  volume_ml: "" | number;
   hop_rate: "" | number;
   extract: "" | number;
   IBU: "" | number;
@@ -54,7 +53,6 @@ const beerAddSchema = z.object({
   brewery: z.number({ coerce: true }),
   style: z.number({ coerce: true }),
   percentage: z.number({ coerce: true }),
-  volume_ml: z.number({ coerce: true }),
   hop_rate: z.number({ coerce: true }).nullable(),
   extract: z.number({ coerce: true }).nullable(),
   IBU: z.number({ coerce: true }).nullable(),
@@ -79,7 +77,6 @@ export default function BeerAddModal({
       brewery: "",
       style: "",
       percentage: "",
-      volume_ml: "",
       hop_rate: "",
       extract: "",
       IBU: "",
@@ -307,16 +304,6 @@ export default function BeerAddModal({
             step={0.1}
             min={0}
             max={40}
-            required
-          />
-          <NumberInput
-            {...form.getInputProps("volume_ml")}
-            name="volume_ml"
-            label="Volume [ml]"
-            placeholder="Enter beer's volume in milliliters"
-            step={10}
-            min={100}
-            max={5000}
             required
           />
           <NumberInput

--- a/src/components/dashboard/browser/BeerCard.tsx
+++ b/src/components/dashboard/browser/BeerCard.tsx
@@ -4,7 +4,6 @@ import {
   CardSection,
   Box,
   Group,
-  Divider,
   Image,
   Text,
 } from "@mantine/core";
@@ -24,7 +23,7 @@ const useStyles = createStyles((theme) => ({
 
 interface BeerCardProps {
   beer: Beer;
-  onClick: (beer: Beer) => void
+  onClick: (beer: Beer) => void;
 }
 
 export default function BeerCard({ beer, onClick }: BeerCardProps) {
@@ -58,8 +57,6 @@ export default function BeerCard({ beer, onClick }: BeerCardProps) {
         <Text align="center">{beer.brewery.name}</Text>
         <Group position="center">
           <Text size="sm">{beer.percentage}%</Text>
-          <Divider orientation="vertical" />
-          <Text size="sm">{beer.volume_ml}ml</Text>
         </Group>
       </Box>
     </Card>

--- a/src/components/dashboard/browser/BeersPage.tsx
+++ b/src/components/dashboard/browser/BeersPage.tsx
@@ -41,7 +41,9 @@ interface BeersPageProps {
 }
 
 export default function BeersPage({ initialData }: BeersPageProps) {
-  const initialDataUpdateAtRef = useRef(new Date().getTime() - BEERS_QUERY_STALE_TIME);
+  const initialDataUpdateAtRef = useRef(
+    new Date().getTime() - BEERS_QUERY_STALE_TIME
+  );
 
   const [search, setSearch] = useState("");
   const [breweriesSearch, setBreweriesSearch] = useState("");
@@ -56,7 +58,6 @@ export default function BeersPage({ initialData }: BeersPageProps) {
   const [breweriesIds, setBreweriesIds] = useState<string[]>([]);
   const [hopsIds, setHopsIds] = useState<string[]>([]);
   const [stylesIds, setStylesIds] = useState<string[]>([]);
-  const [volumeRange, setVolumeRange] = useState<[number, number]>([1, 1000]);
   const [percentageRange, setPercentageRange] = useState<[number, number]>([
     0, 40,
   ]);
@@ -130,7 +131,6 @@ export default function BeersPage({ initialData }: BeersPageProps) {
       style__in: stylesIds.join(","),
       hops__in: hopsIds.join(","),
       percentage__range: percentageRange.join(","),
-      volume_ml__range: volumeRange.join(","),
       search: debouncedSearch,
       page_size: BEERS_PAGE_SIZE,
     } satisfies BeersParams,
@@ -294,33 +294,6 @@ export default function BeersPage({ initialData }: BeersPageProps) {
               }}
               id="percentage-range-slider"
               aria-labelledby="percentage-range-slider-label"
-            />
-          </Box>
-          <Box w={{ base: 200, lg: 240 }} px={{ base: 8, lg: 16 }}>
-            <Text
-              size="sm"
-              weight={600}
-              ml={-8}
-              component="label"
-              id="volume_ml-range-slider-label"
-            >
-              Volume [ml]
-            </Text>
-            <RangeSlider
-              label={(value) => `${value}ml`}
-              step={1}
-              min={1}
-              max={1000}
-              marks={[
-                { value: 1, label: "1ml" },
-                { value: 500, label: "500ml" },
-                { value: 1000, label: "1000ml" },
-              ]}
-              minRange={0}
-              value={volumeRange}
-              onChangeEnd={setVolumeRange}
-              id="volume_ml-range-slider"
-              aria-labelledby="volume_ml-range-slider-label"
             />
           </Box>
           <Flex sx={{ flexGrow: 0.9 }}></Flex>

--- a/src/components/dashboard/purchases/PurchasesPage.tsx
+++ b/src/components/dashboard/purchases/PurchasesPage.tsx
@@ -56,6 +56,7 @@ export default function PurchasesPage({
       volume: undefined,
       purchased_at: undefined,
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [debouncedSearch, ordering]);
 
   const {


### PR DESCRIPTION
From now only BeerPurchase contains `volume_ml` attribute.